### PR TITLE
fix TestTopicalWordCountWithStopWords.test() failure bug.

### DIFF
--- a/examples/src/test/java/com/datasalt/pangool/examples/topicalwordcount/TestTopicalWordCount.java
+++ b/examples/src/test/java/com/datasalt/pangool/examples/topicalwordcount/TestTopicalWordCount.java
@@ -80,7 +80,7 @@ public class TestTopicalWordCount extends AbstractHadoopTestLibrary {
 				}				
 			}
 		}
-		
+		reader.close();
 		return validatedOutputLines;
 	}
 	

--- a/examples/src/test/java/com/datasalt/pangool/examples/topicalwordcount/TestTopicalWordCountWithStopWords.java
+++ b/examples/src/test/java/com/datasalt/pangool/examples/topicalwordcount/TestTopicalWordCountWithStopWords.java
@@ -34,7 +34,7 @@ public class TestTopicalWordCountWithStopWords extends AbstractHadoopTestLibrary
 	
 	@Test
 	public void test() throws Exception {
-		trash(OUTPUT);
+        trash(INPUT, STOP_WORDS, OUTPUT);
 		
 		Configuration conf = new Configuration();
 		
@@ -47,6 +47,7 @@ public class TestTopicalWordCountWithStopWords extends AbstractHadoopTestLibrary
 		
 		// Stop words: bar, bloh
 		Files.write(("bar" + "\n" + "bloh").getBytes("UTF-8"), new File(STOP_WORDS));
+	    trash(OUTPUT);
 		ToolRunner.run(getConf(), new TopicalWordCountWithStopWords(), new String[] { INPUT, OUTPUT, STOP_WORDS });
 
 		assertEquals(3, TestTopicalWordCount.assertOutput(OUTPUT + "/part-r-00000", conf));


### PR DESCRIPTION
close TupleFile.Reader after assert and add trash before each mapreduce
runner.
